### PR TITLE
데이터베이스 접근 로직 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/Article.java
@@ -23,9 +23,8 @@ import java.util.Set;
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy"),
 })
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Article {
+public class Article extends AuditingFields{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -44,19 +43,6 @@ public class Article {
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     @ToString.Exclude
     private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
-
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;    // 생성일자
-    @CreatedBy
-    @Column(nullable = false, length = 100)
-    private String createdBy;           // 생성자
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;   // 수정일자
-    @LastModifiedBy
-    @Column(nullable = false, length = 100)
-    private String modifiedBy;          // 수정자
 
     protected Article() {
     }

--- a/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -20,9 +20,8 @@ import java.util.Objects;
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy"),
 })
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class ArticleComment {
+public class ArticleComment extends AuditingFields{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;            // 댓글 id
@@ -33,19 +32,6 @@ public class ArticleComment {
     @Setter
     @Column(nullable = false, length = 500)
     private String content;     // 본문
-
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;    // 생성일자
-    @CreatedBy
-    @Column(nullable = false, length = 100)
-    private String createdBy;           // 생성자
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;   // 수정일자
-    @LastModifiedBy
-    @Column(nullable = false, length = 100)
-    private String modifiedBy;          // 수정자
 
     protected ArticleComment() {
     }

--- a/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/AuditingFields.java
@@ -1,0 +1,40 @@
+package com.fastcampus.projectboard.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;    // 생성일자
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    private String createdBy;           // 생성자
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime modifiedAt;   // 수정일자
+
+    @LastModifiedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    private String modifiedBy;          // 수정자
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,9 +29,6 @@ spring:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
-  h2:
-    console:
-      enabled: false
   sql:
     init:
       mode: always


### PR DESCRIPTION
생성자, 생성일자, 수정자, 수정일자는 반복적으로 엔티티 클래스에 들어가는 요소이고,
도메인과 직접 연관이 없는 요소이므로
추출이 가능하다

'@MappedSuperclass' 이용하여 상속 방식으로 추출함

그외 '@DateTimeFormat' 요소 추가 및 jpa 옵션 개선

This closes #9 